### PR TITLE
Update to output code.json schema 2.0.0

### DIFF
--- a/api.js
+++ b/api.js
@@ -2,20 +2,28 @@ const request = require('request');
 const http = require('http');
 const url = require('url');
 
+const PORT = process.env.PORT || 3000;
+
 let inventory = {
-  name: "",
-  version: "1.0.1",
-  projects: []
+  version: "2.0.0",
+  agency: "CFPB",
+  measurementType: {
+    method: "projects"
+  },
+  releases: []
 };
 
-codeJson = (org, cb) => {
-  
-  inventory.name = org.toLowerCase();
-  
+codeJson = (params, cb) => {
+  let after = '';
+
+  if (params.after) {
+    after = ` after:"${params.after}"`
+  }
+
   const query = `query($username:String!) {
-    organization(login: $username) {
+    organization(login:$username) {
       name
-      repositories(first: 100) {
+      repositories(first:100 ${after}) {
         nodes {
           name
           description
@@ -24,7 +32,7 @@ codeJson = (org, cb) => {
           owner {
             login
           }
-          repositoryTopics(first: 100) {
+          repositoryTopics(first:3) {
             edges {
               node {
                 topic {
@@ -34,14 +42,18 @@ codeJson = (org, cb) => {
             }
           }
         }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
       }
     }
   }`;
-  
+
   const variables = `{
-    "username": "${inventory.name}"
+    "username": "${params.org}"
   }`;
-  
+
   const options = {
     method: 'POST',
     url: 'https://api.github.com/graphql',
@@ -56,41 +68,58 @@ codeJson = (org, cb) => {
     },
     json: true
   };
-  
+
   request(options, (err, res, body) => {
+    console.log('\npageInfo: ' + body.data.organization.repositories.pageInfo);
+    if (body.data.organization.repositories.pageInfo.hasNextPage) {
+      console.log(
+`There are more results. Open http://localhost:${PORT}?org=${params.org}\
+&after=${body.data.organization.repositories.pageInfo.endCursor} \
+to see the next page.`
+      );
+    }
     if (err) return console.error(error);
     if (!body.data.organization) return cb("Invalid GitHub organization!");
     const inventory = handleResponse(body);
     cb(null, inventory);
   });
-  
+
 };
 
 handleResponse = (body) => {
-  
-  let projects = body.data.organization.repositories.nodes;
-  inventory.projects = projects.map((project) => {
-    let tags = project.repositoryTopics.edges.map((edge) => {
+
+  let releases = body.data.organization.repositories.nodes;
+  inventory.releases = releases.map((release) => {
+    let tags = release.repositoryTopics.edges.map((edge) => {
       return edge.node.topic.name;
     });
-    tags.push(inventory.name);
+    tags.push(inventory.agency);
     tags.sort();
+    if (!release.description) {
+      release.description = ''
+    }
     return {
-      name: project.name,
-      description: project.description,
-      license: project.license,
-      openSourceProject: 1,
-      governmentWideReuseProject: 1,
+      name: release.name,
+      description: release.description,
+      repositoryURL: release.url,
+      permissions: {
+        licenses: [
+          {
+            name: "Public Domain"
+          }
+        ],
+        usageType: "openSource"
+      },
+      laborHours: -1,
       tags: tags,
       contact: {
-        email: `contact@${inventory.name}.gov`
+        email: "tech@consumerfinance.gov"
       },
-      repository: project.url
     }
   });
-  
+
   return inventory;
-  
+
 }
 
 module.exports = codeJson;

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ const PORT = process.env.PORT || 3000;
 const app = http.createServer((req, res) => {
   const params = url.parse(req.url, true).query;
   if (!params.org) {
-    return res.end("Plz specify a GitHub org.");
+    return res.end("Please specify a GitHub org.");
   }
   res.setHeader("Content-Type", "application/json");
-  api(params.org, (err, json) => {
+  api(params, (err, json) => {
     if (err) return res.end(err);
     res.end(JSON.stringify(json))
   });


### PR DESCRIPTION
Also adds `after` query param for easier paging.

I made some changes that made this a bit more CFPB-specific, so we might want to make this like a v2 (of this library) prerelease or something. I think the simple route for making it easier for others to use would be to add more query params for things like `agency`, `measurementType`, `permissions`, and `contact.email`.

But, given the recent discussions of combining the multiple Node code.json generators out there into a single one, it's probably not worth putting that effort in here. This library isn't likely to be built on; it's more likely we might bring some of its unique concepts (like serving it over HTTP) to one of the other, more advanced libraries.

Todos:
- [ ] Update README to describe `after` param usage

I'm going on vacation for 3 weeks; feel free to update as desired to merge!